### PR TITLE
Adapt Star recipe to work with `aarch64`.

### DIFF
--- a/recipes/star/build.sh
+++ b/recipes/star/build.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
-if [ "$(uname)" == "Darwin" ]; then
-    echo "Installing STAR for OSX."
-    mkdir -p $PREFIX/bin
-    cp bin/MacOSX_x86_64/* $PREFIX/bin
-else 
-    echo "Installing STAR for UNIX/Linux."
-    mkdir -p $PREFIX/bin
-    cp bin/Linux_x86_64_static/* $PREFIX/bin
-fi
+
+export CPPFLAGS="-I$PREFIX/include"
+
+cd source
+make STAR CXXFLAGS_SIMD=""
+mkdir -p $PREFIX/bin
+cp STAR $PREFIX/bin
 chmod +x $PREFIX/bin/STAR

--- a/recipes/star/meta.yaml
+++ b/recipes/star/meta.yaml
@@ -9,6 +9,14 @@ source:
   url: https://github.com/alexdobin/STAR/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }} 11
+    - make
+  host:
+    - zlib
+
 build:
   number: 0
 


### PR DESCRIPTION
Current imported version builds but the tests fail with this error:
```
.../bin/STAR: cannot execute binary file
```
because the binary is a `x86_64` executable
```
file .../bin/STAR: ELF 64-bit LSB executable, x86-64, version 1...
```

The problem is that the recipe is not compiling it from source, it is just using the pre-compiled versions that are inside the release `tar.gz`. There is no pre-compiled version for `aarch64` so we need to change the recipe to make it compile from source.

